### PR TITLE
Unpin max pandas version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 3082fe05b0b5301f55452a728959cde2552f90f020a065e6083be5024ddc06bc
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -23,7 +23,7 @@ requirements:
     - cython >=0.29
     - numba >=0.50,<0.53
     - numpy =1.19
-    - pandas >=1.1.0,<1.2
+    - pandas >=1.1.0
     - pip
     - setuptools
     - scikit-learn >=0.23.0
@@ -32,7 +32,7 @@ requirements:
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - pandas >=1.1.0,<1.2
+    - pandas >=1.1.0
     - scikit-learn >=0.23.0
     - statsmodels >=0.12.1
     - numba >=0.50,<0.53

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - cython >=0.29
     - numba >=0.50,<0.53
     - numpy =1.19
-    - pandas >=1.1.0
+    - pandas >=1.1.0,<1.3
     - pip
     - setuptools
     - scikit-learn >=0.23.0
@@ -32,7 +32,7 @@ requirements:
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - pandas >=1.1.0
+    - pandas >=1.1.0,<1.3
     - scikit-learn >=0.23.0
     - statsmodels >=0.12.1
     - numba >=0.50,<0.53


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist

I noticed that the conda recipe sets an upper bound on the pandas version of 1.2.0 but the pypi package does not. I'm creating this PR to see if the build fails if we allow pandas >1.2.0. If it passes, I'll open for review as I think unpinning pandas will be helpful to users.


* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
