### PR TITLE
Add support for Python 3.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,9 @@ source:
   sha256: 6fc2ed6190c2d015813878faa5806068ac7f10f80c42f1e88343fadf62c4c513
 
 build:
-  number: 1
+  number: 2
   skip: true  # [(py==37 and aarch64)]
-  skip: true  # [py<37 or py>310]
+  skip: true  # [py<37 or py>311]
 
 # This section is required to correctly rerender skip statement
 requirements:


### PR DESCRIPTION
The upstream supports [">=3.7,<3.12"](https://github.com/sktime/sktime/blob/19618df351a27b77e3979efc191e53987dbd99ae/pyproject.toml#L41), we should add support for Python 3.11. 

Addressing issue https://github.com/sktime/sktime/issues/4254#issuecomment-1438554815

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
