### PR TITLE
fix conditional depenency `numba` on python 3.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ outputs:
         - deprecated >=1.2.13
         - numpy >=1.21.0,<1.25
         - pandas >=1.1.0,<1.6.0
-        - numba >=0.53
+        - numba >=0.53                           # [py<311]
         - scikit-learn >=0.24.0,<1.3.0
         - scipy >=1.2.0,<2.0.0
       run_constrained:


### PR DESCRIPTION
Removes dependency `numba` on python 3.11