### PR TITLE
fix conditional depenency `numba` on python 3.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 6fc2ed6190c2d015813878faa5806068ac7f10f80c42f1e88343fadf62c4c513
 
 build:
-  number: 2
+  number: 3
   skip: true  # [(py==37 and aarch64)]
   skip: true  # [py<37 or py>311]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ outputs:
         - deprecated >=1.2.13
         - numpy >=1.21.0,<1.25
         - pandas >=1.1.0,<1.6.0
-        - numba >=0.53
+        - numba >=0.53                           # [py<311]
         - scikit-learn >=0.24.0,<1.3.0
         - scipy >=1.2.0,<2.0.0
       run_constrained:


### PR DESCRIPTION
Removes dependency `numba` on python 3.11