### PR TITLE
[ENH] update project metadata - doc location, project location, maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About sktime-suite
 ==================
 
-Home: https://github.com/alan-turing-institute/sktime
+Home: https://github.com/sktime/sktime
 
 Package license: BSD-3-Clause
 
@@ -9,9 +9,9 @@ Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/sktime-feedstoc
 
 Summary: A unified framework for machine learning with time series
 
-Development: https://github.com/alan-turing-institute/sktime
+Development: https://github.com/sktime/sktime
 
-Documentation: https://www.sktime.org/en/latest/
+Documentation: https://www.sktime.net/en/latest/
 
 Current build status
 ====================

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/alan-turing-institute/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  url: https://github.com/sktime/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 6fc2ed6190c2d015813878faa5806068ac7f10f80c42f1e88343fadf62c4c513
 
 build:
@@ -131,18 +131,16 @@ outputs:
         - sktime.utils
 
 about:
-  home: https://github.com/alan-turing-institute/sktime
+  home: https://github.com/sktime/sktime
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
   summary: A unified framework for machine learning with time series
-  doc_url: https://www.sktime.org/en/latest/
-  dev_url: https://github.com/alan-turing-institute/sktime
+  doc_url: https://www.sktime.net/en/latest/
+  dev_url: https://github.com/sktime/sktime
 
 extra:
   recipe-maintainers:
     - fkiraly
     - dhirschfeld
     - freddyaboulton
-    - lmmentel
-    - mloning


### PR DESCRIPTION
Updates project metadata to be accurate:

* `sktime` is no longer at `alan-turing-institute` org since mid-2022, now at `sktime`
* mloning has become inactive in 2021, lmmentel recently
* the `sktime.org` domain has been taken down, the docs are now on `sktime.net`