### PR TITLE
fix `pycatch22` specifier

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,7 @@ outputs:
         - numba >=0.53
         - pmdarima >=1.8.0,!=1.8.1,<3.0.0
         - prophet >=1.1
-        - pycatch22 >=0.4,<0.4.4,
+        - pycatch22 >=0.4,<0.4.4
         - pykalman >=0.9.5
         - pyod >=0.8.0
         - pystan ==2.19.1.1


### PR DESCRIPTION
This fixes the invalid specifier for `pycatch22` in the "all extras" release.